### PR TITLE
Performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,27 +16,30 @@ transform by selecting <img src="/tex/1683127d6422f667f0fd702f2d9f7d89.svg?inver
 ## Example
 
 ```haskell
-import Protolude
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Interpolation where
 
 import Data.Curve.Weierstrass.BN254 (Fr)
 import Data.Pairing.BN254 (getRootOfUnity)
-
+import qualified Data.Vector as V
 import FFT
+import Protolude
 
 k :: Int
 k = 5
 
 polySize :: Int
-polySize = 2^k
+polySize = 2 ^ k
 
-leftCoeffs, rightCoeffs :: [Fr]
-leftCoeffs = map fromIntegral [1..polySize]
-rightCoeffs = map fromIntegral (reverse [1..polySize])
+leftCoeffs, rightCoeffs :: V.Vector Fr
+leftCoeffs  = V.generate polySize fromIntegral
+rightCoeffs = V.generate polySize (fromIntegral . (polySize -))
 
 main :: IO ()
 main = do
-  print (interpolate getRootOfUnity leftCoeffs)
-  print (fftMult getRootOfUnity leftCoeffs rightCoeffs)
+  print $ interpolate getRootOfUnity leftCoeffs
+  print $ fftMult getRootOfUnity leftCoeffs rightCoeffs
   pure ()
 ```
 

--- a/README.tex.md
+++ b/README.tex.md
@@ -16,27 +16,30 @@ transform by selecting $2^m - 1$ roots of unity $\omega \in \mathbb{F}$.
 ## Example
 
 ```haskell
-import Protolude
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Interpolation where
 
 import Data.Curve.Weierstrass.BN254 (Fr)
 import Data.Pairing.BN254 (getRootOfUnity)
-
+import qualified Data.Vector as V
 import FFT
+import Protolude
 
 k :: Int
 k = 5
 
 polySize :: Int
-polySize = 2^k
+polySize = 2 ^ k
 
-leftCoeffs, rightCoeffs :: [Fr]
-leftCoeffs = map fromIntegral [1..polySize]
-rightCoeffs = map fromIntegral (reverse [1..polySize])
+leftCoeffs, rightCoeffs :: V.Vector Fr
+leftCoeffs  = V.generate polySize fromIntegral
+rightCoeffs = V.generate polySize (fromIntegral . (polySize -))
 
 main :: IO ()
 main = do
-  print (interpolate getRootOfUnity leftCoeffs)
-  print (fftMult getRootOfUnity leftCoeffs rightCoeffs)
+  print $ interpolate getRootOfUnity leftCoeffs
+  print $ fftMult getRootOfUnity leftCoeffs rightCoeffs
   pure ()
 ```
 

--- a/bench/Poly.hs
+++ b/bench/Poly.hs
@@ -9,6 +9,7 @@ import Data.Curve.Weierstrass.BN254 (Fr)
 import Data.Pairing.BN254           (getRootOfUnity)
 
 import FFT
+import qualified Data.Vector as V
 
 k :: Int
 k = 5
@@ -16,16 +17,15 @@ k = 5
 polySize :: Int
 polySize = 2^k
 
-leftCoeffs, rightCoeffs :: [Fr]
-leftCoeffs = map fromIntegral [1..polySize]
-rightCoeffs = map fromIntegral (reverse [1..polySize])
+leftCoeffs, rightCoeffs :: V.Vector Fr
+leftCoeffs = V.generate polySize fromIntegral
+rightCoeffs = V.generate polySize (fromIntegral . (polySize -))
 
-points :: [(Fr,Fr)]
+points :: V.Vector (Fr,Fr)
 points
-  = map (\i -> (getRootOfUnity k ^ i, fromIntegral i))
-        [1..polySize]
+  = V.generate polySize (\i -> (getRootOfUnity k ^ i, fromIntegral i))
 
-fftPoints :: [Fr]
+fftPoints :: V.Vector Fr
 fftPoints = map snd points
 
 benchmarks :: [Benchmark]

--- a/examples/Interpolation.hs
+++ b/examples/Interpolation.hs
@@ -4,6 +4,7 @@ module Interpolation where
 
 import Data.Curve.Weierstrass.BN254 (Fr)
 import Data.Pairing.BN254 (getRootOfUnity)
+import qualified Data.Vector as V
 import FFT
 import Protolude
 
@@ -13,9 +14,9 @@ k = 5
 polySize :: Int
 polySize = 2 ^ k
 
-leftCoeffs, rightCoeffs :: [Fr]
-leftCoeffs = map fromIntegral [1 .. polySize]
-rightCoeffs = map fromIntegral (reverse [1 .. polySize])
+leftCoeffs, rightCoeffs :: V.Vector Fr
+leftCoeffs  = V.generate polySize fromIntegral
+rightCoeffs = V.generate polySize (fromIntegral . (polySize -))
 
 main :: IO ()
 main = do

--- a/galois-fft.cabal
+++ b/galois-fft.cabal
@@ -41,7 +41,7 @@ library
       base            >=4.10  && <5
     , elliptic-curve  >=0.3   && <0.4
     , galois-field    >=1.0   && <2.0
-    , poly            >=0.3.2 && <0.4
+    , poly            >=0.5   && <0.6
     , protolude       >=0.2   && <0.3
     , vector          >=0.12  && <0.13
 
@@ -67,7 +67,7 @@ test-suite fft-tests
     , galois-fft
     , galois-field          >=1.0   && <2.0
     , pairing               >=1.0   && <1.1
-    , poly                  >=0.3.2 && <0.4
+    , poly                  >=0.5   && <0.6
     , protolude             >=0.2   && <0.3
     , QuickCheck            >=2.13  && <2.14
     , quickcheck-instances  >=0.3   && <0.4
@@ -100,7 +100,7 @@ benchmark fft-benchmarks
     , galois-fft
     , galois-field    >=1.0   && <2.0
     , pairing         >=1.0   && <1.1
-    , poly            >=0.3.2 && <0.4
+    , poly            >=0.5   && <0.6
     , protolude       >=0.2   && <0.3
     , vector          >=0.12  && <0.13
 

--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,7 @@ dependencies:
   - base           >= 4.10  && < 5
   - protolude      >= 0.2   && < 0.3
   - vector         >= 0.12  && < 0.13
-  - poly           >= 0.3.2 && < 0.4
+  - poly           >= 0.5   && < 0.6
   - elliptic-curve >= 0.3   && < 0.4
   - galois-field   >= 1.0   && < 2.0
 

--- a/src/FFT.hs
+++ b/src/FFT.hs
@@ -89,8 +89,8 @@ fft omega_n as =
 -- | Inverse discrete Fourier transformation, uses FFT.
 inverseDft :: GaloisField k => (Int -> k) -> DFT k -> CoeffVec k
 inverseDft primRootsUnity dft =
-  let n = fromIntegral . length $ dft
-   in map (/ n) $
+  let invN = recip $ fromIntegral $ length dft
+   in map (* invN) $
         fft (recip . primRootsUnity) dft
 
 -- | Append minimal amount of zeroes until the list has a length which

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,10 @@
-resolver: lts-14.7
+resolver: nightly-2020-09-28
 extra-deps:
-  - elliptic-curve-0.3.0
-  - galois-field-1.0.0
-  - poly-0.3.2.0
-  - semirings-0.5.1
-  - pairing-1.0.0
-  - arithmoi-0.8.0.0
+  - poly-0.5.0.0
+  - github: adjoint-io/galois-field
+    commit: aeec6aece4f1b3304721b19d0ece3d9b76644bad
+  - github: adjoint-io/pairing
+    commit: 9e3fd026fb43fd64917a3b267d0d8d351eba77cc
+  - github: adjoint-io/elliptic-curve
+    commit: 445e196a550e36e0f25bd4d9d6a38676b4cf2be8
+allow-newer: true

--- a/test/TestFFT.hs
+++ b/test/TestFFT.hs
@@ -6,6 +6,7 @@ import Data.Curve.Weierstrass.BN254 (Fr)
 import Data.Field.Galois
 import Data.Pairing.BN254 (getRootOfUnity)
 import FFT
+import qualified GHC.Exts
 import Protolude
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
@@ -17,7 +18,7 @@ testExp :: Int
 testExp = 8
 
 instance Arbitrary f => Arbitrary (TestPoly f) where
-  arbitrary = TestPoly <$> vectorOf (2 ^ testExp) arbitrary
+  arbitrary = TestPoly . GHC.Exts.fromList <$> vectorOf (2 ^ testExp) arbitrary
 
 omega :: Fr
 omega = getRootOfUnity testExp


### PR DESCRIPTION
I noticed that there is a room for performance improvements in `fft`.

| Size | Before, ms  | After, ms | Speedup
| :----| ----------: | --------: | -------:
| 2^5  | 1.366       | 0.330     | 4.1x
| 2^6  | 3.393       | 0.758     | 4.5x
| 2^7  | 9.531       | 1.735     | 5.5x
| 2^8  | 22.85       | 4.038     | 5.7x
| 2^9  | 56.32       | 9.557     | 5.9x
| 2^10 | 130.6       | 21.59     | 6.0x
| 2^11 | 294.0       | 47.89     | 6.1x
| 2^12 | 658.4       | 106.9     | 6.2x
| 2^13 | 1481        | 231.4     | 6.4x
| 2^14 | 3362        | 532.2     | 6.3x

(An acceleration of speedups can probably be attributed to forcing thunks earlier)

----

I can restore `type CoeffVec f = [f]`, if it is deemed to be a part of the public API and it is desirable to keep it unchanged. 